### PR TITLE
reuse the replicate vector across resamples

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -22,10 +22,9 @@ auto var(const auto& x) {  // TODO: more careful about parameter type
 }
 
 template <typename T>
-T resample(const T& x, auto& dev) {
+void resample(const T& x, T& replicate, auto& dev) {
   // adapted from https://stackoverflow.com/questions/42926209/equivalent-function-to-numpy-random-choice-in-c
   std::uniform_int_distribution<std::size_t> distribution(0, x.size() - 1);
-  std::vector<typename T::value_type> replicate(x.size());
 
   std::generate_n(
     std::begin(replicate),
@@ -35,19 +34,20 @@ T resample(const T& x, auto& dev) {
     }
   );
 
-  return replicate;
 }
 
 int main() {
-  std::vector<int> x(N);
-  std::iota(std::begin(x), std::end(x), 0);
+  std::vector<double> x(N), replicate(N), results(NUM_REPLICATES);
+  //std::iota(std::begin(x), std::end(x), 0);
+  for (std::size_t i{1}; i < x.size(); ++i) {
+    x[i] = x[i - 1] + 1.0;
+  }
 
-  std::vector<double> results(NUM_REPLICATES);
   std::random_device random_device;
 
   for (std::size_t i{}; i < results.size(); ++i) {  // TODO: split this into pieces, do on different cores
-    const auto current_sample{resample(x, random_device)};
-    results[i] = var(current_sample);
+    resample(x, replicate, random_device);
+    results[i] = var(replicate);
   }
   std::cout << var(results) << '\n';
 }


### PR DESCRIPTION
```
$ valgrind ./a.out
==18252== Memcheck, a memory error detector
==18252== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18252== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==18252== Command: ./a.out
==18252==
699906
==18252==
==18252== HEAP SUMMARY:
==18252==     in use at exit: 0 bytes in 0 blocks
==18252==   total heap usage: 5 allocs, 5 frees, 881,728 bytes allocated
==18252==
==18252== All heap blocks were freed -- no leaks are possible
==18252==
==18252== For lists of detected and suppressed errors, rerun with: -s
==18252== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
$ g++ -Wall -Wextra -Wshadow -Wconversion -Werror -Wpedantic -std=c++20 -O3 main.cpp
$ valgrind ./a.out
==18271== Memcheck, a memory error detector
==18271== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18271== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==18271== Command: ./a.out
==18271==
700693
==18271==
==18271== HEAP SUMMARY:
==18271==     in use at exit: 0 bytes in 0 blocks
==18271==   total heap usage: 100,004 allocs, 100,004 frees, 200,875,728 bytes allocated
==18271==
==18271== All heap blocks were freed -- no leaks are possible
==18271==
==18271== For lists of detected and suppressed errors, rerun with: -s
==18271== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```